### PR TITLE
Remove usage of deprecated Community API for Characters

### DIFF
--- a/src/helpers/BlizzardApi.js
+++ b/src/helpers/BlizzardApi.js
@@ -1,0 +1,256 @@
+import querystring from 'querystring';
+
+import { blizzardApiResponseLatencyHistogram } from 'helpers/metrics';
+import RequestTimeoutError from './request/RequestTimeoutError';
+import RequestSocketTimeoutError from './request/RequestSocketTimeoutError';
+import RequestConnectionResetError from './request/RequestConnectionResetError';
+import RequestUnknownError from './request/RequestUnknownError';
+
+import retryingRequest from './retryingRequest';
+import RegionNotSupportedError from './RegionNotSupportedError';
+
+const REGIONS = {
+  EU: 'EU',
+  US: 'US',
+  TW: 'TW',
+  KR: 'KR',
+};
+
+const HTTP_CODES = {
+  UNAUTHORIZED: 401, // access token invalid/expired
+  NOT_FOUND: 404,
+};
+
+class BlizzardApi { // TODO: extends ExternalApi that provides a generic _fetch method for third party APIs
+  static localeByRegion = {
+    [REGIONS.EU]: 'en_US',
+    [REGIONS.US]: 'en_US',
+    [REGIONS.TW]: 'zh_TW',
+    [REGIONS.KR]: 'ko_KR',
+  };
+
+  async fetchCharacter(regionCode, realm, name) {
+    const region = this._getRegion(regionCode);
+    const realmSlug = this._getRealSlug(realm);
+
+    return this._fetchApi(region, 'character', `/profile/wow/character/${encodeURIComponent(realmSlug)}/${encodeURIComponent(name.toLowerCase())}`, {
+      'namespace': `profile-${region}`,
+    });
+  }
+
+  async fetchCharacterEquipment(regionCode, realm, name) {
+    const region = this._getRegion(regionCode);
+    const realmSlug = this._getRealSlug(realm);
+
+    return this._fetchApi(region, 'character-equipment', `/profile/wow/character/${encodeURIComponent(realmSlug)}/${encodeURIComponent(name.toLowerCase())}/equipment`, {
+      'namespace': `profile-${region}`,
+    });
+  }
+
+  async fetchCharacterMedia(regionCode, realm, name) {
+    const region = this._getRegion(regionCode);
+    const realmSlug = this._getRealSlug(realm);
+
+    return this._fetchApi(region, 'character-media', `/profile/wow/character/${encodeURIComponent(realmSlug)}/${encodeURIComponent(name.toLowerCase())}/character-media`, {
+      'namespace': `profile-${region}`,
+    });
+  }
+
+  async fetchCharacterSpecializations(regionCode, realm, name) {
+    const region = this._getRegion(regionCode);
+    const realmSlug = this._getRealSlug(realm);
+
+    return this._fetchApi(region, 'character-specializations', `/profile/wow/character/${encodeURIComponent(realmSlug)}/${encodeURIComponent(name.toLowerCase())}/specializations`, {
+      'namespace': `profile-${region}`,
+    });
+  }
+
+  // region Internals
+  _accessTokenByRegion = {};
+
+  _makeUrl(region, path, query = {}) {
+    return `https://${region.toLowerCase()}.api.blizzard.com${path}?${querystring.stringify({
+      locale: this.constructor.localeByRegion[region],
+      ...query,
+    })}`;
+  }
+
+  _getRealSlug(realmName) {
+    return realmName.replace(/'/g, "").replace(/\s/g, "-").toLowerCase();
+  }
+
+  _getRegion(regionCode) {
+    const region = REGIONS[regionCode.toUpperCase()];
+
+    if (!region) {
+      throw new RegionNotSupportedError();
+    }
+
+    return region;
+  }
+
+  async _fetchAccessToken(region) {
+    if (!this._accessTokenByRegion[region]) {
+      const url = `https://${region.toLowerCase()}.battle.net/oauth/token?grant_type=client_credentials&client_id=${process.env.BATTLE_NET_API_CLIENT_ID}&client_secret=${process.env.BATTLE_NET_API_CLIENT_SECRET}`;
+
+      const tokenRequest = await this._fetch(url, {
+        category: 'token',
+        region,
+      });
+
+      const tokenData = JSON.parse(tokenRequest);
+      this._accessTokenByRegion[region] = tokenData.access_token;
+    }
+
+    return this._accessTokenByRegion[region];
+  }
+
+  async _fetchApi(region, operation, path, query = null) {
+    const accessToken = await this._fetchAccessToken(region);
+    const url = this._makeUrl(region, path, {
+      access_token: accessToken,
+      ...query,
+    });
+
+    const metricLabels = { category: operation, region };
+    try {
+      return await this._fetch(url, metricLabels);
+    } catch (err) {
+      if (err.statusCode === HTTP_CODES.UNAUTHORIZED) {
+        delete this._accessTokenByRegion[region];
+        // We can recursively call ourself because we just deleted the access token so it will just retry that and if that fails then it will actually stop instead of retrying *forever*.
+        // This is unless Blizzard's API breaks and starts throwing out 401s for valid keys. Let's hope that won't happen.
+        return this._fetchApi(region, endpoint, path, query);
+      }
+      throw err;
+    }
+  }
+
+  _fetch(url, metricLabels) {
+    let commitMetric;
+    return retryingRequest({
+      url,
+      headers: {
+        'User-Agent': process.env.USER_AGENT,
+      },
+      gzip: true,
+      // we'll be making several requests, so pool connections
+      forever: true,
+      // ms after which to abort the request, when a character is uncached it's not uncommon to take ~2sec
+      timeout: 5000, // TODO: Set to 4000 when EU's latency is fixed and average request is below 4 sec
+      // The Blizzard API isn't very reliable in its HTTP codes, so we're very liberal
+      shouldRetry: error => error.statusCode !== HTTP_CODES.NOT_FOUND,
+      onBeforeAttempt: () => {
+        commitMetric = blizzardApiResponseLatencyHistogram.startTimer(metricLabels);
+      },
+      onFailedAttempt: async err => {
+        if (err instanceof RequestTimeoutError) {
+          commitMetric({ statusCode: 'timeout' });
+        } else if (err instanceof RequestSocketTimeoutError) {
+          commitMetric({ statusCode: 'socket timeout' });
+        } else if (err instanceof RequestConnectionResetError) {
+          commitMetric({ statusCode: 'connection reset' });
+        } else if (err instanceof RequestUnknownError) {
+          commitMetric({ statusCode: 'unknown' });
+        } else {
+          commitMetric({ statusCode: err.statusCode });
+        }
+      },
+      onSuccess: () => {
+        commitMetric({ statusCode: 200 });
+      },
+    });
+  }
+  // endregion
+}
+
+export default new BlizzardApi();
+
+export function getCharacterFaction(type) {
+  switch (type) {
+    case "HORDE":
+      return 1;
+    case "ALLIANCE":
+      return 2;
+    default:
+      return null;
+  }
+}
+
+export function getCharacterGender(type) {
+  switch (type) {
+    case "MALE":
+      return 0;
+    case "FEMALE":
+      return 1;
+    default:
+      return null;
+  }
+}
+
+export function getCharacterRole(className, specName) {
+  const rolesByClassAndSpec = {
+    "death knight": {
+      "blood": "TANK",
+      "frost": "DPS",
+      "unholy": "DPS",
+    },
+    "demon hunter": {
+      "havoc": "DPS",
+      "vengeance": "TANK",
+    },
+    "druid": {
+      "balance": "DPS",
+      "feral": "DPS",
+      "guardian": "TANK",
+      "restoration": "HEALING",
+    },
+    "hunter": {
+      "beast mastery": "DPS",
+      "marksmanship": "DPS",
+      "survival": "DPS",
+    },
+    "mage": {
+      "arcane": "DPS",
+      "fire": "DPS",
+      "frost": "DPS",
+    },
+    "monk": {
+      "brewmaster": "TANK",
+      "mistweaver": "HEALING",
+      "windwalker": "DPS",
+    },
+    "paladin": {
+      "holy": "HEALING",
+      "protection": "TANK",
+      "retribution": "DPS",
+    },
+    "priest": {
+      "discipline": "HEALING",
+      "holy": "HEALING",
+      "shadow": "DPS",
+    },
+    "rogue": {
+      "assassination": "DPS",
+      "outlaw": "DPS",
+      "subtlety": "DPS",
+    },
+    "shaman": {
+      "elemental": "DPS",
+      "enhancement": "DPS",
+      "restoration": "HEALING",
+    },
+    "warlock": {
+      "affliction": "DPS",
+      "demonology": "DPS",
+      "destruction": "DPS",
+    },
+    "warrior": {
+      "arms": "DPS",
+      "fury": "DPS",
+      "protection": "TANK",
+    }
+  }
+
+  return className && specName && rolesByClassAndSpec[className.toLowerCase()][specName.toLowerCase()];
+}


### PR DESCRIPTION
[Blizzard has deprecated the Comunity API that WoWAnalyzer relies on to retrieve game  data, such as character data](https://develop.battle.net/documentation/world-of-warcraft/community-api-migration-status). The purpose of this PR is to migrate to the new Blizzard for character data only.

### Notes
About the API integration:
- I've duplicated the `BlizzardCommunityAPI.js` file as the foundation of the client to the non-community API. When all the endpoints (items and spells) are deprecated, we could remove the community API file.
- The community API use to return all the information we needed in a single call, using the `fields` parameter. It's not possible anymore so I had to call multiple endpoints to get the same amount of data back. We still cache all that data so I believe this won't be too much of a problem, but let me know if it is.
- The new API relies on the realm slug (e.g. `marécage-de-Zangar` or `voljin`) instead of the realm name (`Marecage de Zangar` or `Vol'jin`). I've put together a tiny helper to get the realm slug from the realm name (remove all `'` and replace `<SPACE>` by `-`). We could get those from the API too but I think the rules are simple enough not to use [the API](https://develop.battle.net/documentation/world-of-warcraft/game-data-apis). 
- I see we have some metrics to measure the latency of Blizzard's API. Since we now have 4 calls instead of 1, I've split the metrics in 4.

In `index.js`:
- `battlegroups` are deprecated, and `timewalkerLevel` is not returned. They don't seem to be used but I'm keeping the field for now. We can decide to remove it in a sub-sequent PR.
- `role` is not exposed in the new API, so I've built a helper function for that unless you know a better way.
- `heartOfAzeroth`, I've set `icon` and `quality` to static values as I believe they never change.

Let me know what you think :tada: 

### Testing
I've tested using personnal and random WarcraftLogs, and doing comparison of returned JSONs and side by side comparison of pages.

#### Sceenshots
Before:
![https://i.imgur.com/7lWVOy3.png](https://i.imgur.com/7lWVOy3.png)
After:
![https://i.imgur.com/vfVBvIg.png](https://i.imgur.com/vfVBvIg.png)
_(https://www.wowanalyzer.com/report/jtPh7vzTakWBD4xG/9-Heroic+Drest'agath+-+Kill+(5:48))_

I was even able to use the character search:
![https://i.imgur.com/UWKrGjX.png](https://i.imgur.com/UWKrGjX.png)
Notice that it's showing my HPS and not DPS as expected.

#### JSON example
```
{
  "id": 150020145,
  "region": "eu",
  "realm": "Marécage de Zangar",
  "name": "Faufau",
  "battlegroup": "Sturmangriff / Charge",
  "faction": 1,
  "class": 6,
  "race": 10,
  "gender": 0,
  "achievementPoints": 8310,
  "thumbnail": "marecage-de-zangar/49/150020145-avatar.jpg",
  "spec": "Blood",
  "role": "TANK",
  "talents": "0110012",
  "heartOfAzeroth": {
    "id": 158075,
    "name": "Heart of Azeroth",
    "icon": "inv_heartofazeroth",
    "quality": 6,
    "itemLevel": 465,
    "timewalkerLevel": 120,
    "azeriteItemLevel": 66
  },
  "blizzardUpdatedAt": null,
  "createdAt": "2019-04-07T13:42:14.000Z",
  "lastSeenAt": "2019-11-02T10:07:00.000Z"
}
```
(https://www.wowanalyzer.com/i/character/EU/Mar%C3%A9cage%20de%20Zangar/Faufau)

and the same response using this change's code:
```
{
  "id": 150020145,
  "region": "eu",
  "realm": "Marécage de Zangar",
  "name": "Faufau",
  "battlegroup": null,
  "faction": 1,
  "class": 6,
  "race": 10,
  "gender": 0,
  "achievementPoints": 10035,
  "thumbnail": "marecage-de-zangar/49/150020145-avatar.jpg",
  "spec": "Unholy",
  "role": null,
  "talents": "1122021",
  "heartOfAzeroth": {
    "id": 158075,
    "name": "Heart of Azeroth",
    "icon": "inv_heartofazeroth",
    "quality": 6,
    "itemLevel": 511,
    "timewalkerLevel": null,
    "azeriteItemLevel": 89
  },
  "blizzardUpdatedAt": "2020-05-15",
  "createdAt": "2020-05-15T18:38:02.000Z",
  "lastSeenAt": "2020-05-15T18:38:02.000Z"
}
```
The order is tiny bit different but that doesn't matter to the frontend.

---

_Disclaimer: it's been a while since I coded some JS and it was 5+ years ago. I've tried to be quite defensive in the code vs nulls using the `const value = foo.bar && foo.bar.baz` pattern. Let me know if that's not how we do things in 2020._