### PR TITLE
Change oauth token fetch for blizzard API to be POST

### DIFF
--- a/src/helpers/BlizzardApi.js
+++ b/src/helpers/BlizzardApi.js
@@ -117,7 +117,7 @@ class BlizzardApi { // TODO: extends ExternalApi that provides a generic _fetch 
       const tokenRequest = await this._fetch(url, {
         category: 'token',
         region,
-      });
+      }, 'POST');
 
       const tokenData = JSON.parse(tokenRequest);
       this._accessTokenByRegion[region] = tokenData.access_token;
@@ -147,7 +147,7 @@ class BlizzardApi { // TODO: extends ExternalApi that provides a generic _fetch 
     }
   }
 
-  _fetch(url, metricLabels) {
+  _fetch(url, metricLabels, method) {
     let commitMetric;
     return retryingRequest({
       url,
@@ -155,6 +155,7 @@ class BlizzardApi { // TODO: extends ExternalApi that provides a generic _fetch 
         'User-Agent': process.env.USER_AGENT,
       },
       gzip: true,
+      method: method || 'GET',
       // we'll be making several requests, so pool connections
       forever: true,
       // ms after which to abort the request, when a character is uncached it's not uncommon to take ~2sec


### PR DESCRIPTION
This should fix https://github.com/WoWAnalyzer/WoWAnalyzer/issues/4415 and allow people to search by character and guild now

Documentation of change is here: https://us.forums.blizzard.com/en/blizzard/t/http-get-deprecated-for-oauthtoken-endpoint/15232

Example of it working:
<img width="2780" alt="Screen Shot 2021-03-11 at 6 58 15 PM" src="https://user-images.githubusercontent.com/13208452/110885726-39227280-829c-11eb-8494-c5bc8b9f0b92.png">
