### PR TITLE
Add Evokers to the character class roles list.

### DIFF
--- a/src/helpers/BlizzardApi.js
+++ b/src/helpers/BlizzardApi.js
@@ -290,6 +290,10 @@ export function getCharacterRole(className, specName) {
       "arms": "DPS",
       "fury": "DPS",
       "protection": "TANK",
+    },
+    "evoker": {
+      "preservation": "HEALING",
+      "devastation": "DPS"
     }
   }
 


### PR DESCRIPTION
Allows the API to loads Evokers properly so their avatars shows up.

Updated API:
![image](https://user-images.githubusercontent.com/95754/210037824-4f83ab65-98e9-464c-8efb-09e9508d3488.png)

Current:
![image](https://user-images.githubusercontent.com/95754/210037829-e03daf66-b561-4cca-bce2-37003a9ea39a.png)
