### PR TITLE
fix WOWANALYZER-SERVER-BK

### DIFF
--- a/src/helpers/BlizzardApi.js
+++ b/src/helpers/BlizzardApi.js
@@ -1,6 +1,8 @@
 import querystring from 'querystring';
 
-import { blizzardApiResponseLatencyHistogram } from 'helpers/metrics';
+import {
+  blizzardApiResponseLatencyHistogram
+} from 'helpers/metrics';
 import RequestTimeoutError from './request/RequestTimeoutError';
 import RequestSocketTimeoutError from './request/RequestSocketTimeoutError';
 import RequestConnectionResetError from './request/RequestConnectionResetError';
@@ -148,7 +150,12 @@ class BlizzardApi { // TODO: extends ExternalApi that provides a generic _fetch 
       const tokenRequest = await this._fetch(url, {
         category: 'token',
         region,
-      }, { method: 'POST', form: { grant_type: 'client_credentials' }});
+      }, {
+        method: 'POST',
+        form: {
+          grant_type: 'client_credentials'
+        }
+      });
 
       const tokenData = JSON.parse(tokenRequest);
       this._accessTokenByRegion[region] = tokenData.access_token;
@@ -164,7 +171,10 @@ class BlizzardApi { // TODO: extends ExternalApi that provides a generic _fetch 
       ...query,
     });
 
-    const metricLabels = { category: operation, region };
+    const metricLabels = {
+      category: operation,
+      region
+    };
     try {
       return await this._fetch(url, metricLabels);
     } catch (err) {
@@ -198,19 +208,31 @@ class BlizzardApi { // TODO: extends ExternalApi that provides a generic _fetch 
       },
       onFailedAttempt: async err => {
         if (err instanceof RequestTimeoutError) {
-          commitMetric({ statusCode: 'timeout' });
+          commitMetric({
+            statusCode: 'timeout'
+          });
         } else if (err instanceof RequestSocketTimeoutError) {
-          commitMetric({ statusCode: 'socket timeout' });
+          commitMetric({
+            statusCode: 'socket timeout'
+          });
         } else if (err instanceof RequestConnectionResetError) {
-          commitMetric({ statusCode: 'connection reset' });
+          commitMetric({
+            statusCode: 'connection reset'
+          });
         } else if (err instanceof RequestUnknownError) {
-          commitMetric({ statusCode: 'unknown' });
+          commitMetric({
+            statusCode: 'unknown'
+          });
         } else {
-          commitMetric({ statusCode: err.statusCode });
+          commitMetric({
+            statusCode: err.statusCode
+          });
         }
       },
       onSuccess: () => {
-        commitMetric({ statusCode: 200 });
+        commitMetric({
+          statusCode: 200
+        });
       },
       ...options,
     });

--- a/src/modules/character/index.js
+++ b/src/modules/character/index.js
@@ -320,8 +320,7 @@ router.get('/i/character/classic/:id([0-9]+)/:region([A-Z]{2})/:realm([^/]{2,})/
   const { id, region, realm, name } = req.params;
   const storedCharacter = await getStoredCharacter(id);
   let responded = false;
-  // Old cache entries won't have the thumbnail value. We want the thumbnail value. So don't respond yet if it's missing.
-  if (storedCharacter && storedCharacter.thumbnail) {
+  if (storedCharacter) {
     sendJson(res, storedCharacter);
     responded = true;
   }

--- a/src/modules/character/index.js
+++ b/src/modules/character/index.js
@@ -7,6 +7,7 @@ import BlizzardApi, { getFactionFromRace, getFactionFromType, getCharacterGender
 import RegionNotSupportedError from 'helpers/RegionNotSupportedError';
 
 import models from '../../models';
+import moment from 'moment';
 
 const Character = models.Character;
 
@@ -110,9 +111,12 @@ async function getCharacterFromBlizzardForum(guid, region, realm, name) {
   }
 
   let thumbnailAsset = characterData.user.avatar_template || characterData.assets.find(asset => asset.key === 'avatar_template').value;
-  if (thumbnailAsset) {
+  if (thumbnailAsset && thumbnailAsset.includes('worldofwarcraft.com')) {
     thumbnailAsset = thumbnailAsset.split('character/')[1];
     thumbnailAsset = thumbnailAsset.split('?alt=/')[0];
+  } else {
+    // we aren't going to use this asset if it isn't a real render. typically this means the WoW icon is used for the default on someone's profile
+    thumbnailAsset = null;
   }
 
   const json = {
@@ -122,8 +126,9 @@ async function getCharacterFromBlizzardForum(guid, region, realm, name) {
     name: name,
     battlegroup: null, // deprecated in the new Blizzard API
     faction: getFactionFromRace(characterData.user.character.race),
-    class: characterData.user.character.class,
-    race: characterData.user.character.race,
+    // these are part of the forum response, but are not provided in ID form. nulling them out allows the cache to work
+    class: null,
+    race: null,
     gender: null,
     achievementPoints: characterData.user.character.achievement_points || 0,
     thumbnail: thumbnailAsset,
@@ -321,8 +326,11 @@ router.get('/i/character/classic/:id([0-9]+)/:region([A-Z]{2})/:realm([^/]{2,})/
     responded = true;
   }
 
-  // noinspection JSIgnoredPromiseFromCall
-  fetchClassicCharacter(id, region, realm, name, !responded ? res : null);
+  // the forum API is *probably* not intended to be hit as much as the official blizz API. we don't aggressively refresh thumbnails, only hitting it at most once a week per character.
+  if (!storedCharacter || moment().subtract(7, 'days').isAfter(storedCharacter.lastSeenAt)) {
+    // noinspection JSIgnoredPromiseFromCall
+    fetchClassicCharacter(id, region, realm, name, !responded ? res : null);
+  }
 });
 
 export default router;


### PR DESCRIPTION
this is a crash when the thumbnail is not actually a character render, which can occur when hitting the forum api.

this also throttles the forum API use to be *much* less aggressive about refreshing to avoid any downstream headaches