### PR TITLE
enable event limiting / pagination via WCL's built-in event count mechanism

### DIFF
--- a/.env
+++ b/.env
@@ -2,6 +2,9 @@ PORT=3001
 LOGIN_REDIRECT_LOCATION=/premium
 USER_AGENT=WoWAnalyzer.com API
 
+# you probably don't need to change this
+WCL_HOST=https://www.warcraftlogs.com
+
 # This way you can just use the `yarn start` server, though it won't be autorefreshing
 SPA_PROXY_HOST=http://localhost:3000
 

--- a/src/wcl/api.ts
+++ b/src/wcl/api.ts
@@ -1,14 +1,12 @@
 import { request, Variables } from "graphql-request";
 import axios from "axios";
 
-const HOST = "https://www.warcraftlogs.com";
-
 async function fetchToken(): Promise<string | undefined> {
   const basicAuth = Buffer.from(
     `${process.env.WCL_CLIENT_ID}:${process.env.WCL_CLIENT_SECRET}`,
   ).toString("base64");
   const response = await axios.postForm(
-    `${HOST}/oauth/token`,
+    `${process.env.WCL_HOST}/oauth/token`,
     {
       grant_type: "client_credentials",
     },
@@ -39,7 +37,7 @@ export async function query<T, V extends Variables>(
 ): Promise<T> {
   let token = await getToken();
   const run = () =>
-    request<T>(`${HOST}/api/v2/client`, gql, variables, {
+    request<T>(`${process.env.WCL_HOST}/api/v2/client`, gql, variables, {
       Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
       "Accept-Encoding": "deflate,gzip",

--- a/src/wcl/api.ts
+++ b/src/wcl/api.ts
@@ -1,12 +1,14 @@
 import { request, Variables } from "graphql-request";
 import axios from "axios";
 
+const HOST = "https://www.warcraftlogs.com";
+
 async function fetchToken(): Promise<string | undefined> {
   const basicAuth = Buffer.from(
     `${process.env.WCL_CLIENT_ID}:${process.env.WCL_CLIENT_SECRET}`,
   ).toString("base64");
   const response = await axios.postForm(
-    "https://www.warcraftlogs.com/oauth/token",
+    `${HOST}/oauth/token`,
     {
       grant_type: "client_credentials",
     },
@@ -37,7 +39,7 @@ export async function query<T, V extends Variables>(
 ): Promise<T> {
   let token = await getToken();
   const run = () =>
-    request<T>("https://www.warcraftlogs.com/api/v2/client", gql, variables, {
+    request<T>(`${HOST}/api/v2/client`, gql, variables, {
       Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
       "Accept-Encoding": "deflate,gzip",


### PR DESCRIPTION
this may mean that even raid reports require multiple requests temporarily while we fine-tune the event limit value.