### PR TITLE
handle report not found errors

### DIFF
--- a/src/route/wcl/common.ts
+++ b/src/route/wcl/common.ts
@@ -3,6 +3,7 @@ import * as crypto from "node:crypto";
 import { FastifyInstance, FastifyRequest } from "fastify";
 import * as cache from "../../cache.ts";
 import * as Sentry from "@sentry/node";
+import { ApiError, ApiErrorType } from "../../wcl/api.ts";
 
 export type WclProxy<T, P = ReportParams> = { Params: P; Querystring: T };
 export type ReportParams = { code: string };
@@ -95,6 +96,14 @@ export function wrapEndpoint<
           }
         }
       } catch (error) {
+        if (
+          error instanceof ApiError &&
+          error.type === ApiErrorType.NoSuchLog
+        ) {
+          return reply.code(404).send({
+            message: "No log found with that code.",
+          });
+        }
         console.error(error);
         // TODO handle error
         return reply.code(500).send({

--- a/src/route/wcl/fights.ts
+++ b/src/route/wcl/fights.ts
@@ -9,7 +9,6 @@ import {
   ReportPlayer,
   WCLFight,
   WCLReport,
-  WithFights,
 } from "./v1-types";
 
 const fightQuery = gql`


### PR DESCRIPTION
the nested try/catch is pretty ugly but requires larger refactoring to not have. this allows the frontend to identify when loading a log fails because the report is private.